### PR TITLE
Added missing function line_clear

### DIFF
--- a/bed
+++ b/bed
@@ -107,6 +107,12 @@ line_append() {
     buffer[line]+=$REPLY
 }
 
+line_clear() {
+    ((line == 0)) && return
+    cursor goto $((line-base + 2)) 6
+    buffer[line]=""
+}
+
 line_edit() {
     ((line == 0)) && return
     cursor goto $((line-base + 2)) 6 && cursor show


### PR DESCRIPTION
'C' key is bound to ```line_clear``` which doesn't exist. This should fix it.

