### PR TITLE
Fixed default file read, added version flag.

### DIFF
--- a/bed
+++ b/bed
@@ -220,10 +220,21 @@ if file is not given, default to bed.txt.
 EOF
 }
 
+version () {
+cat <<EOF
+$version
+EOF
+}
+
 main () {
-    case $1 in
+    arg=$1
+    if [ $# -eq 0 ]; then
+        arg=$file
+    fi
+    case $arg in
         -h|--help) trap : EXIT; usage;;
-        *) keyboard_loop "$1";;
+        -v|--version) trap : EXIT; version;;
+        *) keyboard_loop "$arg";;
     esac
 }
 

--- a/bed
+++ b/bed
@@ -2,8 +2,11 @@
 
 declare -a buffer
 declare -i line base
-declare file version message
+declare file version message global_config user_config
 bind 'set disable-completion on' 2>/dev/null
+
+global_config="/etc/bedconf"
+user_config="$HOME/.bedconf"
 
 line=0
 base=1
@@ -11,6 +14,9 @@ file="bed.txt"
 version="INDEV"
 message="🛏  Welcome to bed"
 unsaved_changes=0
+
+source $global_config
+source $user_config
 
 shopt -s checkwinsize; (:)
 trap refresh WINCH ALRM


### PR DESCRIPTION
Default file `bed.txt` is not read into the buffer, so it is read if no arguments exist. also version flag missing so added that.